### PR TITLE
modification of mif.py and panelpomp function to resolve the order bug when having unit specific parameters

### DIFF
--- a/pypomp/panelPomp/validation_mixin.py
+++ b/pypomp/panelPomp/validation_mixin.py
@@ -65,4 +65,4 @@ class PanelValidationMixin(Base):
             raise ValueError(
                 "The canonical parameter names must match the canonical parameter names in the unit objects (up to reordering)."
             )
-        self.canonical_param_names = first_unit_canonical_param_names
+        self.canonical_param_names = self.canonical_shared_param_names + self.canonical_unit_param_names


### PR DESCRIPTION
The panel canonical order used internally by `_panel_mif_internal` (shared params concatenated with unit-specific params) did not match the order assumed by `_get_unit_param_permutation` and `mif()`, which used the Pomp dict key order. This caused the permutation to be identity and the random walk perturbation sigmas to be applied to the wrong parameters, leading to catastrophically incorrect IF2 results. The fix sets `canonical_param_names` in `validation_mixin.py` to the actual concat order (shared + unit-specific), permutes sigmas to unit order before passing to `_mif_internal`, inverse-permutes updated thetas back to concat order before splitting, and removes a double-cooling bug where geometric cooling was applied both in `_panel_mif_internal` and again inside `_perfilter_internal`/`_perfilter_helper`.